### PR TITLE
Fix diff output to display removals before additions

### DIFF
--- a/src/Test/Tasty/MGolden.hs
+++ b/src/Test/Tasty/MGolden.hs
@@ -94,13 +94,13 @@ printDetails putStrLn expected actual = ResultDetailsPrinter print
     print :: Int -> (ConsoleFormat -> IO () -> IO ()) -> IO ()
     print _indent formatter
       = traverse_ printDiff
-      $ Diff.getGroupedDiff (Text.lines actual) (Text.lines expected)
+      $ Diff.getGroupedDiff (Text.lines expected) (Text.lines actual)
       where
         printDiff :: Diff.Diff [Text] -> IO ()
         printDiff = \case
           (Diff.Both   line _) -> printLines ' ' neutralFormat line
-          (Diff.First  line)   -> printLines '+' addFormat line
-          (Diff.Second line)   -> printLines '-' removeFormat line
+          (Diff.First  line)   -> printLines '-' removeFormat line
+          (Diff.Second line)   -> printLines '+' addFormat line
 
         printLines :: Char -> ConsoleFormat -> [Text] -> IO ()
         printLines prefix format lines

--- a/src/Test/Tasty/MGolden.hs
+++ b/src/Test/Tasty/MGolden.hs
@@ -94,19 +94,21 @@ printDetails putStrLn expected actual = ResultDetailsPrinter print
     print :: Int -> (ConsoleFormat -> IO () -> IO ()) -> IO ()
     print _indent formatter
       = traverse_ printDiff
-      $ Diff.getDiff (Text.lines actual) (Text.lines expected)
+      $ Diff.getGroupedDiff (Text.lines actual) (Text.lines expected)
       where
-        printDiff :: Diff.Diff Text -> IO ()
+        printDiff :: Diff.Diff [Text] -> IO ()
         printDiff = \case
-          (Diff.Both   line _) -> printLine ' ' neutralFormat line
-          (Diff.First  line)   -> printLine '+' addFormat line
-          (Diff.Second line)   -> printLine '-' removeFormat line
+          (Diff.Both   line _) -> printLines ' ' neutralFormat line
+          (Diff.First  line)   -> printLines '+' addFormat line
+          (Diff.Second line)   -> printLines '-' removeFormat line
 
-        printLine :: Char -> ConsoleFormat -> Text -> IO ()
-        printLine prefix format line
+        printLines :: Char -> ConsoleFormat -> [Text] -> IO ()
+        printLines prefix format lines
           = formatter format
-          . putStrLn
-          $ Text.singleton prefix <> line
+          $ traverse_ printLine lines
+          where
+            printLine :: Text -> IO ()
+            printLine line = putStrLn $ Text.singleton prefix <> line
 
 addFormat :: ConsoleFormat
 addFormat = okFormat

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -24,7 +24,7 @@ testFormat :: TestTree
 testFormat = testCase "diff format" $ do
   ioRef <- newIORef id
   runPrinter $ printDetails (fakePutStrLn ioRef) "foo\nbar" "foo\nbaz"
-  assertEqual "expected diff format" [" foo", "+baz", "-bar"] =<< readPuts ioRef
+  assertEqual "expected diff format" [" foo", "-bar", "+baz"] =<< readPuts ioRef
 
 fakePutStrLn :: IORef ([Text] -> [Text]) -> Text -> IO ()
 fakePutStrLn ioRef text =


### PR DESCRIPTION
Fix #12 by switching around the order in which added and removed lines gets printed.