### PR TITLE
Change to use base-compat prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All 2 tests passed (0.00s)
 
 ### TODOs
 
-PRs on  these are welcome.
+PRs on these are welcome.
 
 * Improve the multi line diff reporting to only show a
   minimal context around the changed hunks.

--- a/package.yaml
+++ b/package.yaml
@@ -4,13 +4,16 @@ github:      mbj/tasty-mgolden
 description: Golden testing provider for tasty with muti-line diff output
 license:     BSD3
 author:      Markus Schirp <mbj@schirp-dso.com>
+tested-with:  GHC == 8.6.5
+            , GHC == 8.8.3
 
 dependencies:
-- Diff     == 0.3.4 || ^>= 0.4
-- base     >= 4.12  && <= 4.15
-- filepath ^>= 1.4.2
-- tasty    ^>= 1.3
-- text     ^>= 1.2
+- Diff        == 0.3.4 || ^>= 0.4
+- base        >= 4.12  && <= 4.15
+- base-compat >= 0.9.0
+- filepath    ^>= 1.4.2
+- tasty      ^>= 1.3
+- text       ^>= 1.2
 
 library:
   source-dirs: src

--- a/src/Test/Tasty/MGolden.hs
+++ b/src/Test/Tasty/MGolden.hs
@@ -1,28 +1,15 @@
 module Test.Tasty.MGolden (Mode(..), goldenTest, printDetails) where
 
-import Control.Applicative (empty, pure)
-import Control.Monad ((=<<))
-import Data.Bool (Bool)
-import Data.Char (Char)
-import Data.Eq (Eq, (==))
+import Control.Applicative (empty)
+import Prelude.Compat hiding (print, putStrLn)
 import Data.Foldable (traverse_)
-import Data.Function (($), (.))
-import Data.Functor ((<$>))
-import Data.Int (Int)
-import Data.Maybe
-import Data.Ord (Ord)
 import Data.Proxy (Proxy(..))
-import Data.Semigroup ((<>))
-import Data.String (String)
 import Data.Text (Text)
 import Data.Typeable (Typeable)
-import System.FilePath (FilePath)
-import System.IO (IO)
 import Test.Tasty
 import Test.Tasty.Options
 import Test.Tasty.Providers
 import Test.Tasty.Providers.ConsoleFormat
-import Text.Show (Show)
 
 import qualified Data.Algorithm.Diff as Diff
 import qualified Data.Text           as Text
@@ -103,9 +90,9 @@ printDetails putStrLn expected actual = ResultDetailsPrinter print
           (Diff.Second line)   -> printLines '+' addFormat line
 
         printLines :: Char -> ConsoleFormat -> [Text] -> IO ()
-        printLines prefix format lines
+        printLines prefix format lines'
           = formatter format
-          $ traverse_ printLine lines
+          $ traverse_ printLine lines'
           where
             printLine :: Text -> IO ()
             printLine line = putStrLn $ Text.singleton prefix <> line
@@ -129,7 +116,7 @@ tryRead path =
     handler
   where
     handler :: Error.IOError -> IO (Maybe Text)
-    handler error =
-      if Error.isDoesNotExistError error
+    handler error' =
+      if Error.isDoesNotExistError error'
         then pure empty
-        else Error.ioError error
+        else Error.ioError error'

--- a/tasty-mgolden.cabal
+++ b/tasty-mgolden.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: dc8328f2190e1309acb51172611879e207bbe3037afc89094a678d358284901a
+-- hash: 818b34dd16ec04aaac8bf7ef47197fd740e6a821b34f053c0114126781c74b1a
 
 name:           tasty-mgolden
 version:        0.0.1
@@ -15,6 +15,7 @@ author:         Markus Schirp <mbj@schirp-dso.com>
 maintainer:     Markus Schirp <mbj@schirp-dso.com>
 license:        BSD3
 license-file:   LICENSE
+tested-with:    GHC == 8.6.5, GHC == 8.8.3
 build-type:     Simple
 
 source-repository head
@@ -33,6 +34,7 @@ library
   build-depends:
       Diff ==0.3.4 || >=0.4 && <0.5
     , base >=4.12 && <=4.15
+    , base-compat >=0.9.0
     , filepath >=1.4.2 && <1.5
     , tasty >=1.3 && <1.4
     , text >=1.2 && <1.3
@@ -45,6 +47,7 @@ executable tasty-mgolden-example
   build-depends:
       Diff ==0.3.4 || >=0.4 && <0.5
     , base >=4.12 && <=4.15
+    , base-compat >=0.9.0
     , filepath >=1.4.2 && <1.5
     , tasty >=1.3 && <1.4
     , tasty-expected-failure
@@ -61,6 +64,7 @@ test-suite golden
   build-depends:
       Diff ==0.3.4 || >=0.4 && <0.5
     , base >=4.12 && <=4.15
+    , base-compat >=0.9.0
     , filepath >=1.4.2 && <1.5
     , tasty >=1.3 && <1.4
     , tasty-expected-failure
@@ -80,6 +84,7 @@ test-suite hlint
   build-depends:
       Diff ==0.3.4 || >=0.4 && <0.5
     , base >=4.12 && <=4.15
+    , base-compat >=0.9.0
     , filepath >=1.4.2 && <1.5
     , hlint >=2.2 && <2.3
     , tasty >=1.3 && <1.4


### PR DESCRIPTION
Base-compat's Prelude makes it easier to take advantage of the latest Prelude that's also compatible with earlier GHC releases. 

So instead of having multiple explicit imports and elimination of the default prelude so as to ensure backward compatibility; we can make use of base-compat's prelude for a compatible prelude.

This PR also doesn't add much in terms of features so feel free to ignore it if you prefer to maintain the explicit imports.

P.S `base-compat` has zero dependencies